### PR TITLE
[routing] Preventing CHECK in case if there's no speed camera.

### DIFF
--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -91,7 +91,7 @@ bool CheckBeepSignal(RoutingSession & routingSession)
 SpeedCameraManager::Interval CheckZone(RoutingSession const & routingSession, double speedKmPH)
 {
   SpeedCameraOnRoute const & closestCamera = routingSession.GetSpeedCamManager().GetClosestCamForTests();
-  CHECK(closestCamera.IsValid(), ("No speed camera found."));
+  TEST(closestCamera.IsValid(), ("No speed camera found."));
 
   double const speedMpS = routing::KMPH2MPS(speedKmPH);
   double const passedDist = routingSession.GetRouteForTests()->GetCurrentDistanceFromBeginMeters();


### PR DESCRIPTION
Если в случае модификации карты не находится камера в тесте, это не правильно прекращать работу тестов. Вообще в интеграционных тестах допустимо, чтоб тесты не проходили в случае, если данные изменились. Но падать с чеком не должны.